### PR TITLE
fix: add yochay and ryan to manual msft list

### DIFF
--- a/dri/report.py
+++ b/dri/report.py
@@ -80,6 +80,8 @@ MICROSFT_EMPLOYEES = [
     'kumar2608',
     'shikhamishra11',
     'washingtonkayaker',
+    'yochay', # Not a MSFT employee anymore, but still owner of lots of issues. Adding here until they are cleaned up.
+    'ryanlengel',
 ]
 
 # When to begin searching for issues.


### PR DESCRIPTION
Found a couple of folks we should manually ignore in our DRI loop on 2019/12/16

## Changes

- Adds yochay and ryanlengel to manual MSFT list