### PR TITLE
Updates v2.0 samples to use the /v{version}/ copy of the manifest

### DIFF
--- a/schemas/skills/v2.0/samples/complex-skillmanifest.json
+++ b/schemas/skills/v2.0/samples/complex-skillmanifest.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+    "$schema": "https://schemas.botframework.com/schemas/skills/v2.0/skill-manifest.json",
     "$id": "SkillBot",
     "name": "Sample skill definition that can handle multiple types of activities",
     "version": "1.0",

--- a/schemas/skills/v2.0/samples/echo-skillmanifest.json
+++ b/schemas/skills/v2.0/samples/echo-skillmanifest.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+    "$schema": "https://schemas.botframework.com/schemas/skills/v2.0/skill-manifest.json",
     "$id": "EchoSkill",
     "name": "Echo skill",
     "version": "1.0",

--- a/schemas/skills/v2.0/samples/simple-skillmanifest.json
+++ b/schemas/skills/v2.0/samples/simple-skillmanifest.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+    "$schema": "https://schemas.botframework.com/schemas/skills/v2.0/skill-manifest.json",
     "$id": "CatchAllSkill",
     "name": "Simple Skill",
     "version": "1.0",


### PR DESCRIPTION
Relates to https://github.com/microsoft/botframework-solutions/issues/3456

Updates the v2.0 sample manifests to point to the version that is in the v2.0 folder and not the backward compat one at the root