### PR TITLE
Update component schema to add $role expression to `expression` and `equalsExpression` definitions

### DIFF
--- a/schemas/component/component.schema
+++ b/schemas/component/component.schema
@@ -66,6 +66,7 @@
             }
         },
         "expression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "description": "Expression to evaluate.",
@@ -75,6 +76,7 @@
             ]
         },
         "equalsExpression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "description": "Expression starting with =.",

--- a/schemas/component/definitions.schema
+++ b/schemas/component/definitions.schema
@@ -33,6 +33,7 @@
             }
         },
         "expression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "pattern": "^.*\\S.*",
@@ -41,6 +42,7 @@
             ]
         },
         "equalsExpression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "pattern": "^=.*\\S.*",

--- a/schemas/component/v1.0/component.schema
+++ b/schemas/component/v1.0/component.schema
@@ -66,6 +66,7 @@
             }
         },
         "expression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "description": "Expression to evaluate.",
@@ -75,6 +76,7 @@
             ]
         },
         "equalsExpression": {
+            "$role": "expression",
             "type": "string",
             "title": "Expression",
             "description": "Expression starting with =.",


### PR DESCRIPTION
Fixes microsoft/botbuilder-dotnet#3839

Composer uses `$role:expression` to determine if a particular property should be rendered with an expression editor UI control. At the moment certain properties that carry `$ref:schema#/definitions/expression` as well as `$ref:schema:#/definitions/equalsExpression` are not rendered as expression controls in composer UI. 

This PR updates the component schema to add the missing `$role: expression` to the definitions. 