### PR TITLE
Update link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ We track functional issues and features asks for the Bot Framework SDK, tools an
 - [Analytics](#Analytics)
 
 ### Bot Framework Composer
-[Bot Framework Composer](https://github.com/microsoft/BotFramework-Composer/blob/stable/README.md) is an integrated development tool for developers and multi-disciplinary teams to build bots and conversational experiences with the Microsoft Bot Framework. Within this tool, you'll find everything you need to build a sophisticated conversational experience.
+[Bot Framework Composer](https://github.com/microsoft/BotFramework-Composer/blob/main/README.md) is an integrated development tool for developers and multi-disciplinary teams to build bots and conversational experiences with the Microsoft Bot Framework. Within this tool, you'll find everything you need to build a sophisticated conversational experience.
 
 ### Botkit
 [Botkit][100] is a developer tool and SDK for building chat bots, apps and custom integrations for major messaging platforms. Botkit bots `hear()` triggers, `ask()` questions and `say()` replies. Developers can use this syntax to build dialogs - now cross compatible with the latest version of Bot Framework SDK.


### PR DESCRIPTION
Fixes #5962 

## Proposed Changes
The [Bot Framework Composer](https://github.com/microsoft/botframework-sdk/blob/master/README.md#bot-framework-composer) link in [README](https://github.com/microsoft/botframework-sdk/blob/master/README.md) 
points to: https://github.com/microsoft/BotFramework-Composer/blob/stable/README.md
should point to: https://github.com/microsoft/BotFramework-Composer/blob/main/README.md

