### PR TITLE
Adding intellisense to uiSchema

### DIFF
--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -57,7 +57,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "examples": ["expressions","user-variables"]
+                    "examples": [["expressions","user-variables"]]
                 },
                 "label": {
                     "title": "Label",

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -50,6 +50,15 @@
                         "type": "string"
                     }
                 },
+                "intellisenseScopes": {
+                    "title": "Intellisense scopes",
+                    "description": "An array of valid scopes to help Intellisense return the correct type of results.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "examples": ["expressions","user-variables"]
+                },
                 "label": {
                     "title": "Label",
                     "description": "Label override. Can either be a string or false to hide the label.",


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotFramework-Composer/issues/4186

## Proposed Changes

In R10, we introduced Intellisense to Composer fields.
For this first release, the mappings between components and valid Intellisense scopes* were hardcoded.
_*Scopes refer to the type of results that Intellisense returns, such as "user-variables"._

In R11, we would like to have the uiSchema dictates this mapping.

Below is a screenshot of how overwriting the uiSchema enables custom Intellisense scopes.
 ![MicrosoftTeams-image](https://user-images.githubusercontent.com/66701106/93649281-78909600-f9c0-11ea-83c1-627d0d684212.png)