### PR TITLE
Add flow uischema definitions in ui.schema

### DIFF
--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -194,7 +194,7 @@
                     "title": "Flow Widget Name",
                     "description": "Flow widget name of current $kind.",
                     "type": "string",
-                    "enum": [
+                    "examples": [
                         "ActionHeader",
                         "ActionCard",
                         "IfConditionWidget",

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -17,6 +17,11 @@
                     "title": "Menu Options",
                     "description": "Configure how this component appears in the menu. Can be a menu option object or an array of menu option objects.",
                     "$ref": "#/definitions/MenuOptions"
+                },
+                "flow": {
+                    "title": "Flow UI Options",
+                    "description": "UI Options object describing flow UI customizations for this $kind.",
+                    "$ref": "#/definitions/FlowUIOptions"
                 }
             },
             "additionalProperties": {
@@ -181,6 +186,24 @@
                 }
             },
             "additionalProperties": false
+        },
+        "FlowUIOptions": {
+            "type": "object",
+            "properties": {
+                "widget": {
+                    "title": "Flow Widget Name",
+                    "description": "Flow widget name of current $kind.",
+                    "type": "string",
+                    "enum": [
+                        "ActionHeader",
+                        "ActionCard",
+                        "IfConditionWidget",
+                        "SwitchConditionWidget",
+                        "ForeachWidget"
+                    ]
+                }
+            },
+            "additionalProperties": true
         },
         "MenuOptions": {
             "oneOf": [


### PR DESCRIPTION
Follows #5955 

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

In #5955, we've checked in the basic ui.schema definition to support customization of Composer's 'form' schema;
based on previous work, this PR appends the 'flow' part to ui.schema definition to support customization of Composer 'flow' schema.

Refs the PR to update botbuilder uischema files: https://github.com/microsoft/botbuilder-dotnet/pull/5099

## About 'flow' schema
Here is flow schema's [Typescript definition](https://github.com/microsoft/BotFramework-Composer/blob/main/Composer/packages/extension-client/src/types/flowSchema.ts).

The only limitaion of flow schema is, it should have a `widget` property which points to a React component name and be rendered as UI elements finally.

Below is an example of the `flow` schema of `Microsoft.EditArray`:
```
{
    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
    "form": {...},
    "flow": {
        "widget": "ActionCard",
        "body": {
            "widget": "ResourceOperation",
            "operation": "=coalesce(action.changeType, \"?\")",
            "resource": "=coalesce(action.itemsProperty, \"?\")"
        },
        "footer": {
            "widget": "PropertyDescription",
            "property": "=action.resultProperty",
            "description": "= Result"
        },
        "hideFooter": "=!action.resultProperty"
    }
}

```
It describes the `Microsoft.EditArray` type in Composer as
![image](https://user-images.githubusercontent.com/8528761/104685778-ccc14200-5736-11eb-8526-ff7a17f7b6f8.png)

Except the `widget` property, all rest properties are wrapped as the props of `widget`. Here is the equivalent React code of this flow schema:
```JSX
<ActionCard
  body={<ResourceOperation operation="" resource="" />}
  footer={<PropertyDescription property="" description="" />}
/>
```
Considering a widget could contain arbitrary props, `'additionalProperties'` is set to `true` in the definition of ui.schema. **Needs review* on that to make sure it doesn't break JSON Schema's convention.


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->