### PR TITLE
Add trigger and recognizer uischema definitions in ui.schema

### DIFF
--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -224,11 +224,6 @@
                     "type": "string",
                     "examples": ["Intent recognized"]
                 },
-                "order": {
-                    "title": "Trigger order (Optional)",
-                    "description": "A float number as the indexing order of a Trigger, be used to sort the Trigger menu.",
-                    "type": "number"
-                },
                 "submenu": {
                     "oneOf": [
                         {
@@ -263,6 +258,11 @@
                     "title": "Trigger disabled",
                     "description": "When set to true, the trigger will be hidden from the creation flow.",
                     "type": "boolean"
+                },
+                "order": {
+                    "title": "Trigger order (Optional)",
+                    "description": "Indexing order of a Trigger, be used to sort the Trigger menu.",
+                    "type": "number"
                 }
             }
         },
@@ -281,16 +281,6 @@
                     "type": "string",
                     "examples": ["LuIntentEditor", "RegexIntentEditor"]
                 },
-                "default": {
-                    "title": "Default recognizer",
-                    "description": "When set to true, new dialogs will use this recognizer by default.",
-                    "type": "boolean"
-                },
-                "disabled": {
-                    "title": "Recognizer disabled",
-                    "description": "When set to true, the recognizer will be hidden from the dropdown.",
-                    "type": "boolean"
-                },
                 "fields": {
                     "title": "Fields initializer object",
                     "description": "A template of the recognizer to define a custom initializer. LG, Expression is supported.",
@@ -301,6 +291,21 @@
                             "luFileId": "${dialogId}.lu"
                         }
                     ]
+                },
+                "default": {
+                    "title": "Default recognizer",
+                    "description": "When set to true, new dialogs will use this recognizer by default.",
+                    "type": "boolean"
+                },
+                "disabled": {
+                    "title": "Recognizer disabled",
+                    "description": "When set to true, the recognizer will be hidden from the dropdown.",
+                    "type": "boolean"
+                },
+                "order": {
+                    "title": "Recognizer order (Optional)",
+                    "description": "Indexing order of a Recognizer, be used to sort the Recognizer dropdown.",
+                    "type": "number"
                 }
             }
         },
@@ -349,15 +354,15 @@
                         }
                     ]
                 },
-                "order": {
-                    "title": "Action menu order (Optional)",
-                    "description": "A float number as the indexing order of an Action, be used to sort the Action menu.",
-                    "type": "number"
-                },
                 "disabled": {
                     "title": "Menu disabled",
                     "description": "When set to true, current $kind will be hidden from the Action flyout menu.",
                     "type": "boolean"
+                },
+                "order": {
+                    "title": "Action menu order (Optional)",
+                    "description": "A float number as the indexing order of an Action, be used to sort the Action menu.",
+                    "type": "number"
                 }
             },
             "additionalProperties": false

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -343,6 +343,11 @@
                     "title": "Action menu order (Optional)",
                     "description": "A float number as the indexing order of an Action, be used to sort the Action menu.",
                     "type": "number"
+                },
+                "disabled": {
+                    "title": "Menu disabled",
+                    "description": "When set to true, current $kind will be hidden from the Action flyout menu.",
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -219,8 +219,8 @@
             "type": "object",
             "properties": {
                 "label": {
-                    "title": "Displayed trigger name"，
-                    "description": "Displayed trigger name in trigger creation flow."，,
+                    "title": "Displayed trigger name",
+                    "description": "Displayed trigger name in trigger creation flow.",
                     "type": "string",
                     "examples": ["Intent recognized"]
                 },
@@ -231,7 +231,10 @@
                 },
                 "submenu": {
                     "oneOf": [
-                        "string",
+                        {
+                            "type": "string",
+                            "description": "Label name of the submenu."
+                        },
                         {
                             "type": "object",
                             "properties": {
@@ -268,7 +271,7 @@
             "properties": {
                 "displayName": {
                     "title": "Recognizer name",
-                    "description": "Recognizer name displayed in the dropdown option."
+                    "description": "Recognizer name displayed in the dropdown option.",
                     "type": "string",
                     "examples": ["Regular expression recognizer"]
                 },
@@ -280,7 +283,8 @@
                 },
                 "default": {
                     "title": "Default recognizer",
-                    "type": "When set to true, new dialogs will use this recognizer by default."
+                    "description": "When set to true, new dialogs will use this recognizer by default.",
+                    "type": "boolean"
                 },
                 "disabled": {
                     "title": "Recognizer disabled",

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -30,6 +30,7 @@
                 },
                 "recognizer": {
                     "title": "Recognizer UI Options",
+                    "description": "UI Options object describing how this component appreas in the Recognizer dropdown.",
                     "$ref": "#/definitions/RecognizerUIOptions"
                 }
             },

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -261,21 +261,36 @@
             "type": "object",
             "properties": {
                 "displayName": {
-                    "type": "string"
+                    "title": "Recognizer name",
+                    "description": "Recognizer name displayed in the dropdown option."
+                    "type": "string",
+                    "examples": ["Regular expression recognizer"]
                 },
                 "intentEditor": {
+                    "title": "Trigger phrases editor name",
+                    "description": "Hook a trigger phrases editor to all child triggers.",
                     "type": "string",
                     "examples": ["LuIntentEditor", "RegexIntentEditor"]
                 },
                 "default": {
-                    "type": "boolean"
+                    "title": "Default recognizer",
+                    "type": "When set to true, new dialogs will use this recognizer by default."
                 },
                 "disabled": {
+                    "title": "Recognizer disabled",,
+                    "description": "When set to true, the recognizer will be hidden from the dropdown.",
                     "type": "boolean"
                 },
                 "fields": {
+                    "title": "Fields initializer object",
+                    "description": "A template of the recognizer to define a custom initializer. LG, Expression is supported.",
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": true,
+                    "examples": [
+                        {
+                            "luFileId": "${dialogId}.lu"
+                        }
+                    ]
                 }
             }
         },

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -22,6 +22,11 @@
                     "title": "Flow UI Options",
                     "description": "UI Options object describing flow UI customizations for this $kind.",
                     "$ref": "#/definitions/FlowUIOptions"
+                },
+                "trigger": {
+                    "title": "Trigger UI Options",
+                    "description": "UI Options object describing how this component appreas in the Trigger dropdown.",
+                    "$ref": "#/definitions/TriggerUIOptions"
                 }
             },
             "additionalProperties": {
@@ -205,6 +210,49 @@
             },
             "additionalProperties": true
         },
+        "TriggerUIOptions": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "title": "Displayed trigger name"，
+                    "description": "Displayed trigger name in trigger creation flow."，,
+                    "type": "string",
+                    "examples": ["Intent recognized"]
+                },
+                "order": {
+                    "title": "Trigger order (Optional)",
+                    "description": "A float number as the indexing order of a Trigger, be used to sort the Trigger menu.",
+                    "type": "number"
+                },
+                "submenu": {
+                    "oneOf": [
+                        "string",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "label": {
+                                    "title": "Submenu name",
+                                    "type": "string",
+                                    "examples": ["Dialog events"]
+                                },
+                                "prompt": {
+                                    "title": "Submenu prompt",
+                                    "description": "Prompt of next level Trigger menu.",
+                                    "type": "string",
+                                    "examples": ["Which event?"]
+                                },
+                                "placeholder": {
+                                    "title": "Submenu placeholder",
+                                    "description": "Placeholder text to show when no trigger selected.",
+                                    "type": "string",
+                                    "examples": ["Select an event type"]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
         "MenuOptions": {
             "oneOf": [
                 {
@@ -252,7 +300,7 @@
                 },
                 "order": {
                     "title": "Action menu order (Optional)",
-                    "description": "A float number as the indexing order of an Action, used to sort the Action menu.",
+                    "description": "A float number as the indexing order of an Action, be used to sort the Action menu.",
                     "type": "number"
                 }
             },

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -255,6 +255,11 @@
                             }
                         }
                     ]
+                },
+                "disabled": {
+                    "title": "Trigger disabled",
+                    "description": "When set to true, the trigger will be hidden from the creation flow.",
+                    "type": "boolean"
                 }
             }
         },
@@ -278,7 +283,7 @@
                     "type": "When set to true, new dialogs will use this recognizer by default."
                 },
                 "disabled": {
-                    "title": "Recognizer disabled",,
+                    "title": "Recognizer disabled",
                     "description": "When set to true, the recognizer will be hidden from the dropdown.",
                     "type": "boolean"
                 },

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -27,6 +27,10 @@
                     "title": "Trigger UI Options",
                     "description": "UI Options object describing how this component appreas in the Trigger dropdown.",
                     "$ref": "#/definitions/TriggerUIOptions"
+                },
+                "recognizer": {
+                    "title": "Recognizer UI Options",
+                    "$ref": "#/definitions/RecognizerUIOptions"
                 }
             },
             "additionalProperties": {
@@ -250,6 +254,28 @@
                             }
                         }
                     ]
+                }
+            }
+        },
+        "RecognizerUIOptions": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "intentEditor": {
+                    "type": "string",
+                    "examples": ["LuIntentEditor", "RegexIntentEditor"]
+                },
+                "default": {
+                    "type": "boolean"
+                },
+                "disabled": {
+                    "type": "boolean"
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": true
                 }
             }
         },

--- a/schemas/ui/v1.0/ui.schema
+++ b/schemas/ui/v1.0/ui.schema
@@ -249,6 +249,11 @@
                             "description": "Do not put menu item in a submenu."
                         }
                     ]
+                },
+                "order": {
+                    "title": "Action menu order (Optional)",
+                    "description": "A float number as the indexing order of an Action, used to sort the Action menu.",
+                    "type": "number"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
Follows #5955 
Follows #6163

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

In #5955, we checked in the basic ui.schema definition to support customization of Composer's 'form' schema;
In #6164, we checked in the 'flow' part to ui.schema definition to support customization of Composer 'flow' schema.

As a follow-up of previous work, this PR appends two extra parts 'trigger' and 'recognizer' to ui.schema definition, it will support the customization of Composer Triggers and Recognizers by using uischema.

References the PR in dotnet runtime repo for updating *.uischema files: https://github.com/microsoft/botbuilder-dotnet/pull/5160

**Changes**
- [x] Add 'trigger' uischema
- [x] Add 'recognizer' uischema
- [x] Update the ‘flow’ uischema (append 'disabled' and 'order' for consistency)

## About 'trigger' schema
Take `Microsoft.OnMessageActivity` as an example:
```js
{
    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
    "form": {...},
    "trigger": {
	"label": "Message received (Message received activity)",
	"order": 5.81,
	"submenu": "Activities"
    }
}
```
Composer will take this uischema and let `OnMessageActivity` appear under 'Activities'
![image](https://user-images.githubusercontent.com/8528761/106896542-ab97b400-672c-11eb-928c-2cee261c40a0.png)


## About 'recognizer' schema
Currently, we only provide limited customization on Recognizer.
In the use case of PVA scenario, by editing the sdk.uischema file like below
```
{
  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
  "Microsoft.PVARecognizer": {
    "recognizer": {
      "displayName": "Default Recognizer (PVA)",
      "default": true
   }
}
```
The PVA recognizer can then be visible as set as default in the Recognizer dropdown
![](https://user-images.githubusercontent.com/8528761/93345867-e96f6b00-f865-11ea-8818-d032bd240b2f.png)


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->