### PR TITLE
Update basemodel to 4.12 (from 4.10) for new models

### DIFF
--- a/Orchestrator/v0.2/nlr_versions.json
+++ b/Orchestrator/v0.2/nlr_versions.json
@@ -26,38 +26,38 @@
     "pretrained.20210205.microsoft.dte.00.12.bert_example_ner.en.onnx": {
       "releaseDate": "02/05/2021",
       "modelUri": "https://aka.ms/pretrained.20210205.microsoft.dte.00.12.bert_example_ner.en.onnx",
-      "description": "(experimental) Bot Framework SDK release 4.10 - English ONNX V1.4 12-layer per-token entity base model",
-      "minSDKVersion": "4.10.0"
+      "description": "(experimental) Bot Framework SDK release 4.12 - English ONNX V1.4 12-layer per-token entity base model",
+      "minSDKVersion": "4.12.0"
     },
     "pretrained.20210218.microsoft.dte.00.12.bert_example_ner.en.onnx": {
       "releaseDate": "02/18/2021",
       "modelUri": "https://aka.ms/pretrained.20210218.microsoft.dte.00.12.bert_example_ner.en.onnx",
-      "description": "(experimental) Bot Framework SDK release 4.10 - English ONNX V1.4 12-layer per-token entity base model",
-      "minSDKVersion": "4.10.0"
+      "description": "(experimental) Bot Framework SDK release 4.12 - English ONNX V1.4 12-layer per-token entity base model",
+      "minSDKVersion": "4.12.0"
     },
     "pretrained.20201210.microsoft.dte.00.12.unicoder_multilingual.onnx": {
       "releaseDate": "12/10/2020",
       "modelUri": "https://aka.ms/pretrained.20201210.microsoft.dte.00.12.unicoder_multilingual.onnx",
-      "description": "Bot Framework SDK release 4.10 - Multilingual ONNX V1.4 12-layer per-token intent base model",
-      "minSDKVersion": "4.10.0"
+      "description": "Bot Framework SDK release 4.12 - Multilingual ONNX V1.4 12-layer per-token intent base model",
+      "minSDKVersion": "4.12.0"
     },
     "pretrained.20210205.microsoft.dte.00.06.bert_example_ner.en.onnx": {
       "releaseDate": "02/05/2021",
       "modelUri": "https://aka.ms/pretrained.20210205.microsoft.dte.00.06.bert_example_ner.en.onnx",
-      "description": "(experimental) Bot Framework SDK release 4.10 - English ONNX V1.4 6-layer per-token entity base model",
-      "minSDKVersion": "4.10.0"
+      "description": "(experimental) Bot Framework SDK release 4.12 - English ONNX V1.4 6-layer per-token entity base model",
+      "minSDKVersion": "4.12.0"
     },
     "pretrained.20210218.microsoft.dte.00.06.bert_example_ner.en.onnx": {
       "releaseDate": "02/18/2021",
       "modelUri": "https://aka.ms/pretrained.20210218.microsoft.dte.00.06.bert_example_ner.en.onnx",
-      "description": "(experimental) Bot Framework SDK release 4.10 - English ONNX V1.4 6-layer per-token entity base model",
-      "minSDKVersion": "4.10.0"
+      "description": "(experimental) Bot Framework SDK release 4.12 - English ONNX V1.4 6-layer per-token entity base model",
+      "minSDKVersion": "4.12.0"
     },
     "pretrained.20210205.microsoft.dte.00.06.unicoder_multilingual.onnx": {
       "releaseDate": "02/05/2021",
       "modelUri": "https://aka.ms/pretrained.20210205.microsoft.dte.00.06.unicoder_multilingual.onnx",
-      "description": "Bot Framework SDK release 4.10 - Multilingual ONNX V1.4 6-layer per-token intent base model",
-      "minSDKVersion": "4.10.0"
+      "description": "Bot Framework SDK release 4.12 - Multilingual ONNX V1.4 6-layer per-token intent base model",
+      "minSDKVersion": "4.12.0"
     }
   }
 }


### PR DESCRIPTION
Update Base Model description to reflect the Bot Framework SDK version when it was created.