### PR TITLE
Fixed Swagger spec

### DIFF
--- a/specs/botframework-protocol/botframework-channel.json
+++ b/specs/botframework-protocol/botframework-channel.json
@@ -579,7 +579,7 @@
         ],
         "summary": "GetConversationMember",
         "description": "Get a single member of a conversation.\r\n\r\nThis REST API takes a ConversationId and MemberId and returns a single ChannelAccount object, if that member is found in this conversation.",
-        "operationId": "Conversations_GetConversationMembers",
+        "operationId": "Conversations_GetConversationMember",
         "consumes": [],
         "produces": [
           "application/json",


### PR DESCRIPTION
In the Swagger spec, the operationId `Conversations_GetConversationMembers` was defined twice, and that caused an issue with the Swagger CLI's validation. One of the two instances should have been `Conversations_GetConversationMember` instead.