### PR TITLE
Removed bf orchestrator plugin instruction since it's no longer a separate bf cli plugin

### DIFF
--- a/Orchestrator/README.md
+++ b/Orchestrator/README.md
@@ -23,13 +23,13 @@ Orchestrator can be used in different development environments:
 - [Bot Framework SDK][24]: Orchestrator can be integrated into your code project by replacing LUIS for intent recognition, such as for skill delegation or dispatching to subsequent language understanding services. See the [SDK integration](#sdk-integration) section for more information. <!--We don't yet document Orchestrator in the SDK docs. Do we need to?-->
 - [Bot Framework Composer][19]: Orchestrator can be selected as a recognizer within Bot Framework Composer. At this point there are limitations to using Orchestrator in Composer, primarily around importing of existing models and tuning recognition performance. (To use Orchestrator, enable the feature flag in your Composer settings.) See the [Composer integration](#composer-integration) section for more information.
 
-In most cases, the [Bot Framework CLI][7] and [Bot Framework CLI Orchestrator plugin][11] is required to prepare and optimize the model for your domain. The [BF Orchestrator command usage][23] page describes how to create, evaluate, and use an Orchestrator model. This diagram illustrates the first part of that process. <!--The diagram leaves off steps 4 and 5.-->
+In most cases, the [Bot Framework CLI][7] is required to prepare and optimize the model for your domain. The [BF Orchestrator command usage][23] page describes how to create, evaluate, and use an Orchestrator model. This diagram illustrates the first part of that process. <!--The diagram leaves off steps 4 and 5.-->
 
 <p align="center">
   <img width="350" src="./docs/media/authoring.png" />
 </p>
 
-**Note**: To use the CLI, first install the [Bot Framework CLI Orchestrator plugin][11].
+**Note**: To use the CLI, first install the [Bot Framework CLI][7].
 
 See the [BF Orchestrator command usage][23] page for instructions on how to create and optimize the language model for your bot.
 
@@ -85,17 +85,14 @@ Orchestrator can be used as recognizer in [Bot Framework Composer][19].
 
 In general, to specify Orchestrator as a dialog recognizer:
 
-1. Enable the Orchestrator feature in Composer's **Application Settings** page. Particularly during the *Preview Release* please make sure to follow the latest up-to-date instructions in [Composer documentation][25].
-2. Select **Orchestrator** in the **Recognizer Type** drop-down menu for your bot.
-3. Review, evaluate and adjust examples in language data as you would normally for LUIS to ensure recognition quality. 
+1. Select **Orchestrator** in the **Recognizer Type** drop-down menu for your bot.
+2. Review, evaluate and adjust examples in language data as you would normally for LUIS to ensure recognition quality. 
 
-This enables basic intent recognition. For more advanced scenarios follow the steps above to import and tune up routing quality. For more information about recognizers in Composer, see the discussion of [recognizers](https://docs.microsoft.com/composer/concept-dialog#recognizer) with respect to dialogs in Composer.
+This enables basic intent recognition. For more advanced scenarios follow the steps above to import and tune up routing quality. For more information about recognizers in Composer, see the discussion of [recognizers](https://docs.microsoft.com/composer/concept-dialog#recognizer) with respect to dialogs in Composer.  Please make sure to follow the latest up-to-date instructions in [Composer documentation][25]
 
 ## Limitations
 
 * Orchestrator is limited to intents only. Entity definitions are ignored and no entity extraction is performed during recognition.
-* Only English language recognition is available in this preview release.
-* Only the *default* base model is available to Orchestrator solutions.
 
 ## Platform Support
 Orchestrator supports the following platforms.
@@ -116,7 +113,7 @@ C# .NET Core 3.1
 - [Tech overview][18]
 - [API reference][14]
 - [Roadmap](./docs/Overview.md#Roadmap)
-- [BF CLI Orchestrator plugin][11]
+- [BF CLI Orchestrator commands][11]
 - [C# samples][12]
 - [NodeJS samples][13]
 - [BF Orchestrator Command Usage][23]
@@ -130,14 +127,14 @@ See the [School skill navigator](https://github.com/microsoft/BotBuilder-Samples
 [5]:https://docs.microsoft.com/azure/bot-service/bot-builder-tutorial-dispatch?tabs=cs
 [6]:https://aka.ms/adaptive-dialogs
 [7]:https://github.com/microsoft/botframework-cli
-[8]:https://github.com/microsoft/botframework-cli/tree/master/packages/luis#bf-luisversionexport
-[9]:https://github.com/microsoft/botframework-cli/tree/master/packages/luis#bf-luisconvert
-[10]:https://github.com/microsoft/botframework-cli/tree/master/packages/qnamaker#bf-qnamakerkbexport
-[11]:https://github.com/microsoft/botframework-cli/tree/beta/packages/orchestrator
+[8]:https://github.com/microsoft/botframework-cli/tree/main/packages/luis#bf-luisversionexport
+[9]:https://github.com/microsoft/botframework-cli/tree/main/packages/luis#bf-luisconvert
+[10]:https://github.com/microsoft/botframework-cli/tree/main/packages/qnamaker#bf-qnamakerkbexport
+[11]:https://github.com/microsoft/botframework-cli/tree/main/packages/orchestrator
 [12]:https://github.com/microsoft/BotBuilder-Samples/tree/main/experimental/orchestrator/csharp_dotnetcore
 [13]:https://github.com/microsoft/BotBuilder-Samples/tree/main/experimental/orchestrator/javascript_nodejs
 [14]:https://aka.ms/bforchestratorapi
-[16]:https://github.com/microsoft/botframework-cli/tree/beta/packages/orchestrator#bf-orchestratorcreate
+[16]:https://github.com/microsoft/botframework-cli/tree/main/packages/orchestrator#bf-orchestratorcreate
 [18]:./docs/Overview.md
 [19]: https://docs.microsoft.com/composer/introduction
 [20]: https://aka.ms/NLRModels "Natural Language Representation Models"

--- a/Orchestrator/docs/BFOrchestratorReport.md
+++ b/Orchestrator/docs/BFOrchestratorReport.md
@@ -176,4 +176,4 @@ This evaluation report is created using several thresholds that they can also be
 [2]:https://en.wikipedia.org/wiki/Confusion_matrix	"Wikipedia: Confusion matrix"
 [3]:https://aka.ms/nlrmodels	"NLR Models"
 [4]:https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lu-file-format?view=azure-bot-service-4.0 ".LU format"
-[5]: https://github.com/microsoft/botframework-cli/tree/beta/packages/orchestrator#bf-orchestratortest "bf orchestrator:test"
+[5]: https://github.com/microsoft/botframework-cli/tree/main/packages/orchestrator#bf-orchestratortest "bf orchestrator:test"

--- a/Orchestrator/docs/BFOrchestratorUsage.md
+++ b/Orchestrator/docs/BFOrchestratorUsage.md
@@ -93,7 +93,7 @@ Create a label .lu file with test data set of utterances. Run the following comm
 bf orchestrator:test --in <snapshot file> --model <base model file> --out <report folder> --test <test data file>
 ```
 
-See also [bf orchestrator test](https://github.com/microsoft/botframework-cli/tree/beta/packages/orchestrator#bf-orchestratortest) for full command line options.
+See also [bf orchestrator test](https://github.com/microsoft/botframework-cli/tree/main/packages/orchestrator#bf-orchestratortest) for full command line options.
 
 See also [Report Interpretation][6] for how to use the report to fine tune your language model. 
 

--- a/Orchestrator/docs/DispatchMigrationExample.md
+++ b/Orchestrator/docs/DispatchMigrationExample.md
@@ -521,5 +521,5 @@ Compile and run. The sample will use Orchestrator to arbitrate ("dispatch") to t
 [4]:https://luis.ai "LUIS"
 [5]:https://qnamaker.ai "QnAMaker"
 [6]:https://github.com/microsoft/botframework-cli "BF CLI"
-[7]:https://github.com/microsoft/botframework-cli/tree/beta/packages/orchestrator "Orchestrator plugin"
+[7]:https://github.com/microsoft/botframework-cli/tree/main/packages/orchestrator "Orchestrator plugin"
 [8]:https://github.com/microsoft/botbuilder-tools/tree/master/packages/Dispatch "Dispatch CLI"

--- a/Orchestrator/docs/DispatchMigrationExample.md
+++ b/Orchestrator/docs/DispatchMigrationExample.md
@@ -21,7 +21,6 @@ Here, we will modify that sample to use Orchestrator in place of the top LUIS ar
   * Have access to create & use [LUIS][4] and [QnAMaker][5] services.
   * See [Dispatch Sample documentation][1] for full details.
 * Install [BF CLI][6]
-* Install BF CLI [Orchestrator Plugin][7]
 * Bot project must target x64 platform
 * Install latest supported version of [Visual C++ runtime](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads)
 

--- a/parsers/LU/JS/packages/lu/package.json
+++ b/parsers/LU/JS/packages/lu/package.json
@@ -14,7 +14,7 @@
   ],
   "homepage": "https://github.com/microsoft/botframework-cli",
   "license": "MIT",
-  "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/lu",
+  "repository": "https://github.com/microsoft/botframework-cli/tree/main/packages/lu",
   "scripts": {
     "postpack": "",
     "posttest": "tslint -p test -t stylish",


### PR DESCRIPTION
Remove separate bf orchestrator plugin install instruction and updated links to Orchestrator cli (beta -> main)

Fixes # 6261