### PR TITLE
Add validation for skill manifest examples against skill manifest schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,16 @@
 
 # Build results
 [Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+ecf/
+rcf/
 
 bones/
 .vs/

--- a/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
+++ b/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
@@ -7,36 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\v2.0\Samples\complex-skillmanifest.json" Link="2.0\Samples\complex-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.0\Samples\echo-skillmanifest.json" Link="2.0\Samples\echo-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.0\Samples\simple-skillmanifest.json" Link="2.0\Samples\simple-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.0\skill-manifest.json" Link="2.0\skill-manifest.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <EmbeddedResource Include="..\v2.1\Samples\complex-pva-manifest.json" Link="2.1\Samples\complex-pva-manifest.json" />
-    <EmbeddedResource Include="..\v2.1\Samples\complex-skillmanifest.json" Link="2.1\Samples\complex-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.1\Samples\echo-skillmanifest.json" Link="2.1\Samples\echo-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.1\Samples\simple-skillmanifest.json" Link="2.1\Samples\simple-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.1\skill-manifest.json" Link="2.1\skill-manifest.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <EmbeddedResource Include="..\v2.2\Samples\complex-pva-manifest.json" Link="2.2\Samples\complex-pva-manifest.json" />
-    <EmbeddedResource Include="..\v2.2\Samples\complex-skillmanifest.json" Link="2.2\Samples\complex-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.2\Samples\echo-skillmanifest.json" Link="2.2\Samples\echo-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.2\Samples\RelativeUris\complex-skillmanifest.json" Link="2.2\Samples\relativeUris\complex-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.2\Samples\simple-skillmanifest.json" Link="2.2\Samples\simple-skillmanifest.json" />
-    <EmbeddedResource Include="..\v2.2\skill-manifest.json" Link="2.2\skill-manifest.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
-    <PackageReference Include="NJsonSchema" Version="10.4.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
+    <PackageReference Include="NJsonSchema" Version="10.4.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
+++ b/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\v2.2\Samples\complex-pva-manifest.json" Link="2.2\Samples\complex-pva-manifest.json" />
+    <EmbeddedResource Include="..\v2.2\Samples\complex-skillmanifest.json" Link="2.2\Samples\complex-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.2\Samples\echo-skillmanifest.json" Link="2.2\Samples\echo-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.2\Samples\RelativeUris\complex-skillmanifest.json" Link="2.2\Samples\relativeUris\complex-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.2\Samples\simple-skillmanifest.json" Link="2.2\Samples\simple-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.2\skill-manifest.json" Link="2.2\skill-manifest.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="NJsonSchema" Version="10.4.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="2.2\Samples\relativeUris\" />
+  </ItemGroup>
+
+</Project>

--- a/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
+++ b/schemas/skills/SchemaManifestTests/SchemaManifestTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,6 +6,21 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="..\v2.0\Samples\complex-skillmanifest.json" Link="2.0\Samples\complex-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.0\Samples\echo-skillmanifest.json" Link="2.0\Samples\echo-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.0\Samples\simple-skillmanifest.json" Link="2.0\Samples\simple-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.0\skill-manifest.json" Link="2.0\skill-manifest.json" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="..\v2.1\Samples\complex-pva-manifest.json" Link="2.1\Samples\complex-pva-manifest.json" />
+    <EmbeddedResource Include="..\v2.1\Samples\complex-skillmanifest.json" Link="2.1\Samples\complex-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.1\Samples\echo-skillmanifest.json" Link="2.1\Samples\echo-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.1\Samples\simple-skillmanifest.json" Link="2.1\Samples\simple-skillmanifest.json" />
+    <EmbeddedResource Include="..\v2.1\skill-manifest.json" Link="2.1\skill-manifest.json" />
+  </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="..\v2.2\Samples\complex-pva-manifest.json" Link="2.2\Samples\complex-pva-manifest.json" />
     <EmbeddedResource Include="..\v2.2\Samples\complex-skillmanifest.json" Link="2.2\Samples\complex-skillmanifest.json" />
@@ -22,10 +37,6 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="2.2\Samples\relativeUris\" />
   </ItemGroup>
 
 </Project>

--- a/schemas/skills/SchemaManifestTests/SchemaManifestTests.sln
+++ b/schemas/skills/SchemaManifestTests/SchemaManifestTests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31409.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchemaManifestTests", "SchemaManifestTests.csproj", "{53609E6C-0C2C-4DB2-864C-628BE29495E4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53609E6C-0C2C-4DB2-864C-628BE29495E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53609E6C-0C2C-4DB2-864C-628BE29495E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53609E6C-0C2C-4DB2-864C-628BE29495E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53609E6C-0C2C-4DB2-864C-628BE29495E4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DB082524-0CE2-4C94-BA0E-A9FFDBE8EE42}
+	EndGlobalSection
+EndGlobal

--- a/schemas/skills/SchemaManifestTests/ValidateSchemaTests.cs
+++ b/schemas/skills/SchemaManifestTests/ValidateSchemaTests.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SchemaManifestTests
+{
+    public class ValidateSchemaTests
+    {
+        private static string GetContent(string manifesResourcetName)
+        {
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            string resourceName = assembly.GetManifestResourceNames().FirstOrDefault(r => r.EndsWith(manifesResourcetName, StringComparison.InvariantCulture));
+            using (var f = new System.IO.StreamReader(assembly.GetManifestResourceStream(resourceName)))
+            {
+                return f.ReadToEnd();
+            }
+        }
+
+        private static Task<JsonSchema> GetSchema(string schemaName)
+        {
+            var skillManifestSchema = GetContent(schemaName);
+
+            return JsonSchema.FromJsonAsync(skillManifestSchema, null, (x) =>
+            {
+                var schemaResolver = new JsonSchemaResolver(x, new JsonSchemaGeneratorSettings());
+                var referenceResolver = new JsonReferenceResolver(schemaResolver);
+                referenceResolver.AddDocumentReference("http://json-schema.org/draft-07/schema", JsonSchema.CreateAnySchema());
+
+                return referenceResolver;
+            });
+        }
+
+        [Theory]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.RelativeUris.complex-skillmanifest.json")]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.complex-pva-manifest.json")]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.complex-skillmanifest.json")]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.echo-skillmanifest.json")]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.simple-skillmanifest.json")]
+        public async Task Verify2_2(string schema, string manifest)
+        {
+            var rawManifest = JsonConvert.DeserializeObject<JObject>(GetContent(manifest));
+
+            var schemaErrors = (await GetSchema(schema)).Validate(rawManifest);
+
+            Assert.Empty(schemaErrors);
+        }
+
+
+    }
+}

--- a/schemas/skills/SchemaManifestTests/ValidateSchemaTests.cs
+++ b/schemas/skills/SchemaManifestTests/ValidateSchemaTests.cs
@@ -36,12 +36,19 @@ namespace SchemaManifestTests
         }
 
         [Theory]
-        [InlineData("2._2.skill-manifest.json", "2._2.Samples.RelativeUris.complex-skillmanifest.json")]
+        [InlineData("2._0.skill-manifest.json", "2._0.Samples.complex-skillmanifest.json")]
+        [InlineData("2._0.skill-manifest.json", "2._0.Samples.echo-skillmanifest.json")]
+        [InlineData("2._0.skill-manifest.json", "2._0.Samples.simple-skillmanifest.json")]
+        [InlineData("2._1.skill-manifest.json", "2._1.Samples.complex-pva-manifest.json")]
+        [InlineData("2._1.skill-manifest.json", "2._1.Samples.complex-skillmanifest.json")]
+        [InlineData("2._1.skill-manifest.json", "2._1.Samples.echo-skillmanifest.json")]
+        [InlineData("2._1.skill-manifest.json", "2._1.Samples.simple-skillmanifest.json")]
+        [InlineData("2._2.skill-manifest.json", "2._2.Samples.relativeUris.complex-skillmanifest.json")]
         [InlineData("2._2.skill-manifest.json", "2._2.Samples.complex-pva-manifest.json")]
         [InlineData("2._2.skill-manifest.json", "2._2.Samples.complex-skillmanifest.json")]
         [InlineData("2._2.skill-manifest.json", "2._2.Samples.echo-skillmanifest.json")]
         [InlineData("2._2.skill-manifest.json", "2._2.Samples.simple-skillmanifest.json")]
-        public async Task Verify2_2(string schema, string manifest)
+        public async Task VerifySchemas(string schema, string manifest)
         {
             var rawManifest = JsonConvert.DeserializeObject<JObject>(GetContent(manifest));
 

--- a/schemas/skills/v2.1/skill-manifest.json
+++ b/schemas/skills/v2.1/skill-manifest.json
@@ -1,7 +1,7 @@
 {
     "$id": "https://schemas.botframework.com/schemas/skills/v2.1/skill-manifest.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$version": "2.1.0",
+    "$version": "2.1.1",
     "title": "Skill Manifest Schema",
     "description": "A schema for Bot Framework skill manifests",
     "type": "object",
@@ -206,8 +206,11 @@
             "properties": {
                 "type": {
                     "type": "string",
+                    "title": "Activity Type",
                     "description": "The activity type",
-                    "const": "event"
+                    "enum": [
+                        "event"
+                    ]
                 },
                 "name": {
                     "type": "string",
@@ -245,8 +248,11 @@
             "properties": {
                 "type": {
                     "type": "string",
+                    "title": "Activity Type",
                     "description": "The activity type",
-                    "const": "invoke"
+                    "enum": [
+                        "invoke"
+                    ]
                 },
                 "name": {
                     "type": "string",
@@ -284,8 +290,9 @@
                 "type": {
                     "type": "string",
                     "description": "The activity type",
-                    "const": "message",
-                    "default": "message"
+                    "enum": [
+                        "message"
+                    ]
                 },
                 "description": {
                     "type": "string",
@@ -315,11 +322,8 @@
                 "type": {
                     "type": "string",
                     "title": "Activity Type",
-                    "description": "Contains the activity type (message, event, invoke, etc.)",
+                    "description": "The activity type",
                     "enum": [
-                        "message",
-                        "event",
-                        "invoke",
                         "messageReaction",
                         "endOfConversation",
                         "handoff",
@@ -332,8 +336,7 @@
                         "deleteUserData",
                         "messageUpdate",
                         "messageDelete"
-                    ],
-                    "pattern":"^(?!(message|event|invoke)$)((messageReaction|endOfConversation|handoff|typing|conversationUpdate|trace|installationUpdate|contactRelationUpdate|suggestion|deleteUserData|messageUpdate|messageDelete)$)"
+                    ]
                 }
             },
             "additionalProperties": true

--- a/schemas/skills/v2.2/skill-manifest.json
+++ b/schemas/skills/v2.2/skill-manifest.json
@@ -206,8 +206,11 @@
             "properties": {
                 "type": {
                     "type": "string",
+                    "title": "Activity Type",
                     "description": "The activity type",
-                    "const": "event"
+                    "enum": [
+                        "event"
+                    ]
                 },
                 "name": {
                     "type": "string",
@@ -245,8 +248,11 @@
             "properties": {
                 "type": {
                     "type": "string",
+                    "title": "Activity Type",
                     "description": "The activity type",
-                    "const": "invoke"
+                    "enum": [
+                        "invoke"
+                    ]
                 },
                 "name": {
                     "type": "string",
@@ -284,8 +290,9 @@
                 "type": {
                     "type": "string",
                     "description": "The activity type",
-                    "const": "message",
-                    "default": "message"
+                    "enum": [
+                        "message"
+                    ]
                 },
                 "description": {
                     "type": "string",
@@ -315,11 +322,8 @@
                 "type": {
                     "type": "string",
                     "title": "Activity Type",
-                    "description": "Contains the activity type (message, event, invoke, etc.)",
+                    "description": "The activity type",
                     "enum": [
-                        "message",
-                        "event",
-                        "invoke",
                         "messageReaction",
                         "endOfConversation",
                         "handoff",
@@ -332,8 +336,7 @@
                         "deleteUserData",
                         "messageUpdate",
                         "messageDelete"
-                    ],
-                    "pattern":"^(?!(message|event|invoke)$)((messageReaction|endOfConversation|handoff|typing|conversationUpdate|trace|installationUpdate|contactRelationUpdate|suggestion|deleteUserData|messageUpdate|messageDelete)$)"
+                    ]
                 }
             },
             "additionalProperties": true


### PR DESCRIPTION
Failures:

![image](https://user-images.githubusercontent.com/11055362/122505886-1518b080-cfb2-11eb-8dee-3ab17dc16b57.png)


Example failure:

(schema: "2._1.skill-manifest.json", manifest: "2._1.Samples.complex-pva-manifest.json") 

Failure Collection: 
```
[AdditionalPropertiesNotValid: #/activities.bookFlight 
{   NotOneOf: #/activities.bookFlight   {   }   {   }   
{     NoAdditionalPropertiesAllowed: #/activities.bookFlight.name   }   
{     PatternMismatch: #/activities.bookFlight.type   }    } ,
 
AdditionalPropertiesNotValid: #/activities.getWeather 
{   NotOneOf: #/activities.getWeather   {   }   {   }   
{     NoAdditionalPropertiesAllowed: #/activities.getWeather.name   }   
{     PatternMismatch: #/activities.getWeather.type   }    } ,
 
AdditionalPropertiesNotValid: #/activities.typing 
{   NotOneOf: #/activities.typing   {     PropertyRequired: #/activities.typing.name   }   
{     PropertyRequired: #/activities.typing.name   }   {   }   {   }    } , 

AdditionalPropertiesNotValid: #/activities.conversationUpdate 
{   NotOneOf: #/activities.conversationUpdate   
{     PropertyRequired: #/activities.conversationUpdate.name   }   
{     PropertyRequired: #/activities.conversationUpdate.name   }   {   }   {   }    } ]
```