### PR TITLE
Update Orchestrator support for MacOS 10.14 to 10.15

### DIFF
--- a/Orchestrator/Samples/dotnet/nlp-with-entities/README.md
+++ b/Orchestrator/Samples/dotnet/nlp-with-entities/README.md
@@ -18,7 +18,7 @@ This bot uses Orchestrator to route user utterances to multiple LUIS models and 
 | OS      | Version             | Architectures   |
 | ------- | ------------------- | --------------- |
 | Windows | 10 (1607+)          | ia32 (x86), x64 |
-| MacOS   | 10.14+              | x64             |
+| MacOS   | 10.15+              | x64             |
 | Linux   | Ubuntu 18.04, 20.04 | x64             |
 
 This sample **requires** prerequisites in order to run.


### PR DESCRIPTION
Update Orchestrator support for MacOS 10.14 to 10.15 (not supported anymore).