### PR TITLE
ConversationAccount non-id fields are optional

### DIFF
--- a/schemas/protocol/botframework.json
+++ b/schemas/protocol/botframework.json
@@ -186,10 +186,7 @@
                 }
             },
             "required": [
-                "conversationType",
-                "id",
-                "isGroup",
-                "name"
+                "id"
             ]
         },
         "MessageReaction": {


### PR DESCRIPTION
This change matches the current written specification, see https://github.com/microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#conversation

Fixes #6541

## Proposed Changes
  - ConversationAccount.name is optional
  - ConversationAccount.isGroup is optional
  - ConversationAccount.conversationType is optional


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->