### PR TITLE
Removes unnecessary assignment in parsePredictedResultToLu

### DIFF
--- a/parsers/LU/JS/packages/lu/src/parser/luis/luConverter.js
+++ b/parsers/LU/JS/packages/lu/src/parser/luis/luConverter.js
@@ -182,7 +182,6 @@ const parsePredictedResultToLu =  function(utterance, luisJSON){
         }
         let passText = utterance.predictedResult.EntityPass ? "> PASS." : "> FAIL.";
         if(updatedText) fileContent +=  passText + ' Predicted entities: ' + updatedText + NEWLINE;
-        updatedText = utterance.text;
     }
     return fileContent
 }


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - Removes unnecessary assignment in `parsePredictedResultToLu`, since `updatedText` is not used


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
—